### PR TITLE
encode: set sample_aspect_ratio on AVStream struct

### DIFF
--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -422,6 +422,11 @@ static struct mux_stream *encode_lavc_add_stream(struct encode_lavc_context *ctx
 
     dst->encoder_timebase = info->timebase;
     dst->st->time_base = info->timebase; // lavf will change this on muxer init
+    // Some muxers (e.g. Matroska one) expect the sample_aspect_ratio to be
+    // set on the AVStream.
+    if (info->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+        dst->st->sample_aspect_ratio = info->codecpar->sample_aspect_ratio;
+    
     if (avcodec_parameters_copy(dst->st->codecpar, info->codecpar) < 0)
         MP_HANDLE_OOM(0);
 


### PR DESCRIPTION
Some libavformat muxers (e.g. matroskaenc.c) expect this field to be set
on the AVStream struct, and not only in the AVCodecParameters.
I agree that my changes can be relicensed to LGPL 2.1 or later.
